### PR TITLE
Add virtual environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Byte-compiled / optimized / library files
+__pycache__/
+*.py[cod]
+*$py.class
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# PPTX to H5P Converter
+
+This tool converts a PowerPoint presentation into an H5P Course Presentation package. It extracts images, text, simple shapes and media files, generating a directory ready for `h5p-cli pack`.
+
+## Requirements
+- Python 3.8+
+- `python-pptx`
+- `h5p-cli` (optional, for packaging)
+
+It is recommended to use a virtual environment. Create one with:
+```bash
+./setup_env.sh
+```
+This script creates a `.venv` folder and installs the requirements.
+
+If you prefer to do it manually, run:
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+```bash
+python script.py myslides.pptx -o output_dir --pack
+```
+The `--pack` flag calls `h5p-cli` to produce a `.h5p` archive automatically. Without it, the output directory can be packed later using `h5p-cli pack output_dir`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-pptx>=0.6

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- document using a virtual environment in README
- ignore `.venv` folder
- add `setup_env.sh` to automate environment creation

## Testing
- `python -m py_compile script.py`


------
https://chatgpt.com/codex/tasks/task_e_6877c4fbb76883229d455826176ec6ce