### PR TITLE
Use Docker for packing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # PPTX to H5P Converter
 
-This tool converts a PowerPoint presentation into an H5P Course Presentation package. It extracts images, text, simple shapes and media files, generating a directory ready for `h5p-cli pack`.
+This tool converts a PowerPoint presentation into an H5P Course Presentation package. It extracts images, text, simple shapes and media files, generating a directory ready for packaging with `h5p-cli` or the `jagalindo/h5p_cli_docker` image.
 
 ## Requirements
 - Python 3.8+
 - `python-pptx`
-- `h5p-cli` (optional, for packaging)
+- Docker (for packaging with the `jagalindo/h5p_cli_docker` image)
 
 It is recommended to use a virtual environment. Create one with:
 ```bash
@@ -24,4 +24,7 @@ pip install -r requirements.txt
 ```bash
 python script.py myslides.pptx -o output_dir --pack
 ```
-The `--pack` flag calls `h5p-cli` to produce a `.h5p` archive automatically. Without it, the output directory can be packed later using `h5p-cli pack output_dir`.
+The `--pack` flag uses the Docker image `jagalindo/h5p_cli_docker` to produce a `.h5p` archive automatically. Without it, the output directory can be packaged later with:
+```bash
+docker run --rm -v /path/to/output_dir:/data jagalindo/h5p_cli_docker h5p pack /data
+```

--- a/script.py
+++ b/script.py
@@ -156,12 +156,21 @@ def convert_pptx_to_h5p(input_pptx, output_dir='h5p_content', pack=False):
     print(f"H5P package structure generated in '{output_dir}'.")
     if pack:
         try:
-            subprocess.run(["h5p-cli", "pack", output_dir], check=True)
+            subprocess.run([
+                "docker", "run", "--rm",
+                "-v", f"{os.path.abspath(output_dir)}:/data",
+                "jagalindo/h5p_cli_docker",
+                "h5p", "pack", "/data"
+            ], check=True)
         except Exception as exc:
             print(f"Packing failed: {exc}")
     else:
-        print("Run 'h5p-cli pack' to create the .h5p archive, for example:")
-        print(f"    h5p-cli pack {output_dir}")
+        print("Run the Docker image 'jagalindo/h5p_cli_docker' to create the .h5p archive, for example:")
+        abs_dir = os.path.abspath(output_dir)
+        print(
+            "    docker run --rm -v "
+            f"{abs_dir}:/data jagalindo/h5p_cli_docker h5p pack /data"
+        )
 
 if __name__ == "__main__":
     import argparse
@@ -169,8 +178,14 @@ if __name__ == "__main__":
     parser.add_argument("pptx_file", help="Path to the .pptx file to convert")
     parser.add_argument("-o", "--output", default="h5p_content",
                         help="Output directory for the H5P package structure")
-    parser.add_argument("--pack", action="store_true",
-                        help="Pack the generated directory into an .h5p file using h5p-cli")
+    parser.add_argument(
+        "--pack",
+        action="store_true",
+        help=(
+            "Pack the generated directory into an .h5p file using the "
+            "jagalindo/h5p_cli_docker image"
+        ),
+    )
     args = parser.parse_args()
 
     convert_pptx_to_h5p(args.pptx_file, args.output, pack=args.pack)


### PR DESCRIPTION
## Summary
- use `jagalindo/h5p_cli_docker` image when `--pack` is selected
- document Docker usage in README

## Testing
- `python script.py --help` *(fails: ModuleNotFoundError: No module named 'pptx')*

------
https://chatgpt.com/codex/tasks/task_e_6883531782b083229584657a7561add5