### PR TITLE
Handle extensions before packing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # PPTX to H5P Converter
 
-This tool converts a PowerPoint presentation into an H5P Course Presentation package. It extracts images, text, simple shapes and media files, generating a directory ready for packaging with `h5p-cli` or the `jagalindo/h5p_cli_docker` image.
+This tool converts a PowerPoint presentation into an H5P Course Presentation package. It extracts images, text, simple shapes and media files, generating a directory ready for packaging with `h5p-cli` or the `jagalindo/h5p-cli` image.
 
 ## Requirements
 - Python 3.8+
 - `python-pptx`
-- Docker (for packaging with the `jagalindo/h5p_cli_docker` image)
+- Docker (for packaging with the `jagalindo/h5p-cli` image)
 
 It is recommended to use a virtual environment. Create one with:
 ```bash
@@ -24,7 +24,8 @@ pip install -r requirements.txt
 ```bash
 python script.py myslides.pptx -o output_dir --pack
 ```
-The `--pack` flag uses the Docker image `jagalindo/h5p_cli_docker` to produce a `.h5p` archive automatically. Without it, the output directory can be packaged later with:
+The `--pack` flag uses the Docker image `jagalindo/h5p-cli` to produce a `.h5p` archive automatically. It first copies the default extensions from the image and then packs the directory. Without the flag, you can do the same manually with:
 ```bash
-docker run --rm -v /path/to/output_dir:/data jagalindo/h5p_cli_docker h5p pack /data
+docker run --rm -v /path/to/output_dir:/data jagalindo/h5p-cli \
+  sh -c 'cp -r /root/.h5p /data/ && h5p-cli pack /data'
 ```


### PR DESCRIPTION
## Summary
- copy H5P extensions from the Docker image before packing
- use `jagalindo/h5p-cli` image and `h5p-cli pack` command
- update README instructions

## Testing
- `python -m py_compile script.py`
- `python script.py --help` *(fails: ModuleNotFoundError: 'pptx')*

------
https://chatgpt.com/codex/tasks/task_e_68835843c67c83229dca627f2e2dfbd6