### PR TITLE
Fix packaging directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ python script.py myslides.pptx -o output_dir --pack
 The `--pack` flag uses the Docker image `jagalindo/h5p-cli` to produce a `.h5p` archive automatically. It first copies the default extensions from the image and then packs the directory. Without the flag, you can do the same manually with:
 ```bash
 docker run --rm -v /path/to/output_dir:/data jagalindo/h5p-cli \
-  sh -c 'cp -r /root/.h5p /data/ && h5p-cli pack /data'
+  sh -c 'mkdir -p /data/.h5p && cp -r /usr/local/lib/h5p/* /data/.h5p/ && h5p-cli pack /data'
 ```

--- a/script.py
+++ b/script.py
@@ -19,7 +19,8 @@ def copy_extensions(target_dir):
         "docker", "run", "--rm",
         "-v", f"{os.path.abspath(target_dir)}:/data",
         "jagalindo/h5p-cli",
-        "sh", "-c", "cp -r /root/.h5p /data/"
+        "sh", "-c",
+        "mkdir -p /data/.h5p && cp -r /usr/local/lib/h5p/* /data/.h5p/"
     ], check=True)
 
 def emu_to_px(emu):


### PR DESCRIPTION
## Summary
- update script to copy built-in libraries from `/usr/local/lib/h5p/`
- update README to show new packaging command

## Testing
- `python3 -m py_compile script.py`


------
https://chatgpt.com/codex/tasks/task_e_68835a83477c832282f4accb4f6cf860