### PR TITLE
Fix packaging command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PPTX to H5P Converter
 
-This tool converts a PowerPoint presentation into an H5P Course Presentation package. It extracts images, text, simple shapes and media files, generating a directory ready for packaging with `h5p-cli` or the `jagalindo/h5p-cli` image.
+This tool converts a PowerPoint presentation into an H5P Course Presentation package. It extracts images, text, simple shapes and media files, generating a directory ready for packaging with the `h5p` command (from the `@lumieducation/h5p-cli` package) or the `jagalindo/h5p-cli` Docker image.
 
 ## Requirements
 - Python 3.8+
@@ -27,5 +27,5 @@ python script.py myslides.pptx -o output_dir --pack
 The `--pack` flag uses the Docker image `jagalindo/h5p-cli` to produce a `.h5p` archive automatically. It first copies the default extensions from the image and then packs the directory. Without the flag, you can do the same manually with:
 ```bash
 docker run --rm -v /path/to/output_dir:/data jagalindo/h5p-cli \
-  sh -c 'mkdir -p /data/.h5p && cp -r /usr/local/lib/h5p/* /data/.h5p/ && h5p-cli pack /data'
+  sh -c 'mkdir -p /data/.h5p && cp -r /usr/local/lib/h5p/* /data/.h5p/ && h5p pack /data || h5p-cli pack /data'
 ```

--- a/script.py
+++ b/script.py
@@ -2,8 +2,8 @@
 
 This script extracts images, text (with basic formatting), simple shapes and
 media from a PowerPoint file and builds the folder structure expected by
-``h5p-cli pack``. Pass ``--pack`` on the command line to automatically invoke
-``h5p-cli`` once conversion finishes.
+``h5p pack`` (or ``h5p-cli pack``). Pass ``--pack`` on the command line to
+automatically invoke the CLI once conversion finishes.
 """
 
 from pptx import Presentation
@@ -36,7 +36,8 @@ def convert_pptx_to_h5p(input_pptx, output_dir='h5p_content', pack=False):
     Parameters:
       input_pptx -- path to the ``.pptx`` file.
       output_dir -- destination folder for the generated H5P directory tree.
-      pack -- when ``True`` automatically invoke ``h5p-cli pack``.
+      pack -- when ``True`` automatically invoke ``h5p`` (or ``h5p-cli``)
+              to pack the output directory.
 
     The resulting folder contains ``h5p.json`` plus a ``content`` directory
     with ``content.json`` and copied media assets.  Images are stored in
@@ -186,7 +187,7 @@ def convert_pptx_to_h5p(input_pptx, output_dir='h5p_content', pack=False):
                 "-v", f"{os.path.abspath(output_dir)}:/data",
                 "jagalindo/h5p-cli",
                 "sh", "-c",
-                "h5p-cli pack /data"
+                "h5p pack /data || h5p-cli pack /data"
             ], check=True)
         except Exception as exc:
             print(f"Packing failed: {exc}")
@@ -197,7 +198,7 @@ def convert_pptx_to_h5p(input_pptx, output_dir='h5p_content', pack=False):
         abs_dir = os.path.abspath(output_dir)
         print(
             "    docker run --rm -v "
-            f"{abs_dir}:/data jagalindo/h5p-cli sh -c 'cp -r /root/.h5p /data/ && h5p-cli pack /data'"
+            f"{abs_dir}:/data jagalindo/h5p-cli sh -c 'cp -r /root/.h5p /data/ && h5p pack /data || h5p-cli pack /data'"
         )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update docs to mention `h5p` command
- ensure script tries `h5p` before `h5p-cli`

## Testing
- `python -m py_compile script.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68835d8ee2208322aaac0716175f8e6b