### PR TITLE
Fix pack option help text

### DIFF
--- a/script.py
+++ b/script.py
@@ -212,7 +212,7 @@ if __name__ == "__main__":
         action="store_true",
         help=(
             "Pack the generated directory into an .h5p file using the "
-            "jagalindo/h5p_cli_docker image"
+            "jagalindo/h5p-cli Docker image"
         ),
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- clarify `--pack` option help wording in `script.py`

## Testing
- `python3 -m py_compile script.py`

------
https://chatgpt.com/codex/tasks/task_e_6883605980f8832297e7ba917ecd2466