### PR TITLE
Copy only required libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,18 @@ Updating the image ensures the bundled H5P libraries are up to date.
 ```bash
 python script.py myslides.pptx -o output_dir --pack
 ```
-The `--pack` flag copies the default H5P libraries from the Docker image and
-creates a `.h5p` archive. Libraries are copied under `.h5p/libraries` inside the
-output directory but the final archive places them at the package root just like
-`h5p-cli pack` does. Without the flag, you can copy the libraries and zip the
-directory manually:
+The `--pack` flag resolves the dependencies listed in `h5p.json` and copies only
+those libraries (and their dependencies) from the Docker image before creating
+a `.h5p` archive. Libraries are placed under `.h5p/libraries` inside the output
+directory but the final archive keeps them at the package root just like
+`h5p-cli pack` does. Without the flag you can still copy the required libraries
+manually and zip the directory:
 ```bash
 docker run --rm -v /path/to/output_dir:/data jagalindo/h5p-cli \
-  sh -c 'mkdir -p /data/.h5p && cp -r /usr/local/lib/h5p/* /data/.h5p/'
+  sh -c 'mkdir -p /data/.h5p && cp -r \
+    /usr/local/lib/h5p/H5P.CoursePresentation-1.23 \
+    /usr/local/lib/h5p/H5P.Text-1.5 \
+    /usr/local/lib/h5p/H5P.Image-1.3 \
+    /data/.h5p/libraries/'
 cd output_dir && zip -r ../output_dir.h5p .
 ```


### PR DESCRIPTION
## Summary
- gather Course Presentation dependencies recursively from Docker
- copy only required H5P libraries when packing
- document the new packing behaviour

## Testing
- `python3 -m py_compile script.py`

------
https://chatgpt.com/codex/tasks/task_e_688381c7d8148322b09e5d9b29f9c336