### PR TITLE
Add recursive option for library packing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PPTX to H5P Converter
 
-This tool converts a PowerPoint presentation into an H5P Course Presentation package. It extracts images, text, simple shapes and media files, generating a directory ready to be zipped into a `.h5p` archive. The optional `--pack` flag copies only the libraries referenced in the generated `h5p.json` (and their recursive dependencies) from the `jagalindo/h5p-cli` Docker image before creating the archive automatically.
+This tool converts a PowerPoint presentation into an H5P Course Presentation package. It extracts images, text, simple shapes and media files, generating a directory ready to be zipped into a `.h5p` archive. The optional `--pack` flag copies the libraries referenced in the generated `h5p.json` from the `jagalindo/h5p-cli` Docker image before creating the archive automatically. Use `-r` to also resolve dependencies recursively.
 
 ## Requirements
 - Python 3.8+
@@ -37,12 +37,12 @@ Updating the image ensures the bundled H5P libraries are up to date.
 ```bash
 python script.py myslides.pptx -o output_dir --pack
 ```
-The `--pack` flag resolves the dependencies listed in `h5p.json`, copies only
-those libraries (and their own dependencies) from the Docker image and then
-creates a `.h5p` archive. Libraries are copied under `.h5p/libraries` inside the
-output directory but the final archive places them at the package root just like
-`h5p-cli pack` does. Without the flag, you can copy the libraries and zip the
-directory manually:
+The `--pack` flag copies the libraries listed in `h5p.json` from the Docker
+image and creates a `.h5p` archive. Add `-r` to also copy any dependencies of
+those libraries recursively. Libraries are copied under `.h5p/libraries` inside
+the output directory but the final archive places them at the package root just
+like `h5p-cli pack` does. Without the flag, you can copy the libraries and zip
+the directory manually:
 ```bash
 docker run --rm -v /path/to/output_dir:/data jagalindo/h5p-cli \
   sh -c 'mkdir -p /data/.h5p && cp -r /usr/local/lib/h5p/<Lib> /data/.h5p/'


### PR DESCRIPTION
## Summary
- update script to support optional recursive dependency copy
- add `-r/--recursive` flag for CLI
- update README with new behaviour

## Testing
- `python -m py_compile script.py`

------
https://chatgpt.com/codex/tasks/task_e_68839218a64c8322b9cf4bec5f419b76