### PR TITLE
Improve packaging feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ docker build -t jagalindo/h5p-cli .
 ```
 Updating the image ensures the bundled H5P libraries are up to date.
 
+If you encounter messages such as `cp: cannot stat '/usr/local/lib/h5p/...'`,
+the Docker image may be missing those libraries. Pull the latest image again:
+
+```bash
+docker pull jagalindo/h5p-cli:latest
+```
+
 ## Usage
 ```bash
 python script.py myslides.pptx -o output_dir --pack

--- a/script.py
+++ b/script.py
@@ -324,6 +324,9 @@ def convert_pptx_to_h5p(input_pptx, output_dir='h5p_content', pack=False, recurs
     text_ver = _get_latest_library_version("H5P.Text")
     image_ver = _get_latest_library_version("H5P.Image")
 
+    if pack and (None in cp_ver or None in text_ver or None in image_ver):
+        print("Warning: unable to detect library versions. Ensure Docker is installed and run 'docker pull jagalindo/h5p-cli:latest' if packaging fails.")
+
     h5p_json = {
         "title": os.path.splitext(os.path.basename(input_pptx))[0],
         "mainLibrary": "H5P.CoursePresentation",


### PR DESCRIPTION
## Summary
- warn rather than abort when required H5P libraries aren't detected

## Testing
- `python -m py_compile script.py`


------
https://chatgpt.com/codex/tasks/task_e_688393c9f6ac83228a8ad191dc86bf32