### PR TITLE
Handle dev files when packing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ The `--pack` flag copies the libraries listed in `h5p.json` from the Docker
 image and creates a `.h5p` archive. Add `-r` to also copy any dependencies of
 those libraries recursively. Libraries are copied under `.h5p/libraries` inside
 the output directory but the final archive places them at the package root just
-like `h5p-cli pack` does. Without the flag, you can copy the libraries and zip
-the directory manually:
+like `h5p-cli pack` does. When packing, common development artifacts such as
+`.git` folders or `tests` directories are automatically skipped. Without the
+flag, you can copy the libraries and zip the directory manually:
 ```bash
 docker run --rm -v /path/to/output_dir:/data jagalindo/h5p-cli \
   sh -c 'mkdir -p /data/.h5p && cp -r /usr/local/lib/h5p/<Lib> /data/.h5p/'

--- a/script.py
+++ b/script.py
@@ -164,12 +164,16 @@ def create_h5p_archive(source_dir, archive_path=None):
 
     library_root = os.path.join(source_dir, ".h5p", "libraries")
 
+    # Names of files or directories that should be ignored when packaging
+    unwanted = {".git", ".babelrc", ".github", "tests"}
+
     with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        for root, _, files in os.walk(source_dir):
+        for root, dirs, files in os.walk(source_dir):
             # Skip the internal .h5p directory altogether
             if os.path.relpath(root, source_dir).startswith(".h5p"):
                 continue
-            for fname in files:
+            dirs[:] = [d for d in dirs if d not in unwanted]
+            for fname in [f for f in files if f not in unwanted]:
                 fpath = os.path.join(root, fname)
                 arcname = os.path.relpath(fpath, source_dir)
                 zf.write(fpath, arcname)
@@ -178,9 +182,12 @@ def create_h5p_archive(source_dir, archive_path=None):
         # archive root.  Only copy the libraries themselves.
         if os.path.isdir(library_root):
             for lib in os.listdir(library_root):
+                if lib in unwanted:
+                    continue
                 lib_path = os.path.join(library_root, lib)
-                for root, _, files in os.walk(lib_path):
-                    for fname in files:
+                for root, dirs, files in os.walk(lib_path):
+                    dirs[:] = [d for d in dirs if d not in unwanted]
+                    for fname in [f for f in files if f not in unwanted]:
                         fpath = os.path.join(root, fname)
                         arcname = os.path.relpath(fpath, library_root)
                         zf.write(fpath, arcname)


### PR DESCRIPTION
## Summary
- skip dev directories such as `.git` when creating the H5P archive
- document that packing excludes development artifacts

## Testing
- `python -m py_compile script.py`
- Unable to run full conversion due to missing `python-pptx` and docker

------
https://chatgpt.com/codex/tasks/task_e_6886607cc26083228b0550725444670b