### PR TITLE
Add option to pack without libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # PPTX to H5P Converter
 
-This tool converts a PowerPoint presentation into an H5P Course Presentation package. It extracts images, text, simple shapes and media files, generating a directory ready to be zipped into a `.h5p` archive. The optional `--pack` flag copies the libraries referenced in the generated `h5p.json` from the `jagalindo/h5p-cli` Docker image before creating the archive automatically. Use `-r` to also resolve dependencies recursively.
+This tool converts a PowerPoint presentation into an H5P Course Presentation package. It extracts images, text, simple shapes and media files, generating a directory ready to be zipped into a `.h5p` archive. Pass `--pack` to create the `.h5p` file automatically. Use `--include-libraries` to copy the libraries referenced in the generated `h5p.json` from the `jagalindo/h5p-cli` Docker image before packaging. Add `-r` to also resolve dependencies recursively.
 
 ## Requirements
 - Python 3.8+
 - `python-pptx`
-- Docker (used by the `--pack` option to copy libraries)
+- Docker (needed when using `--include-libraries`)
 
 It is recommended to use a virtual environment. Create one with:
 ```bash
@@ -44,13 +44,17 @@ docker pull jagalindo/h5p-cli:latest
 ```bash
 python script.py myslides.pptx -o output_dir --pack
 ```
-The `--pack` flag copies the libraries listed in `h5p.json` from the Docker
-image and creates a `.h5p` archive. Add `-r` to also copy any dependencies of
-those libraries recursively. Libraries are copied under `.h5p/libraries` inside
-the output directory but the final archive places them at the package root just
-like `h5p-cli pack` does. When packing, common development artifacts such as
-`.git` folders or `tests` directories are automatically skipped. Without the
-flag, you can copy the libraries and zip the directory manually:
+This packs the generated directory into `output_dir.h5p` without bundling the
+H5P libraries. To also include the libraries listed in `h5p.json` run:
+```bash
+python script.py myslides.pptx -o output_dir --pack --include-libraries
+```
+Add `-r` to also copy any dependencies of those libraries recursively.
+Libraries are stored under `.h5p/libraries` inside the output directory but the
+final archive places them at the package root just like `h5p-cli pack` does.
+When packing, common development artifacts such as `.git` folders or `tests`
+directories are automatically skipped. Without the flag you can copy the
+libraries and zip the directory manually:
 ```bash
 docker run --rm -v /path/to/output_dir:/data jagalindo/h5p-cli \
   sh -c 'mkdir -p /data/.h5p && cp -r /usr/local/lib/h5p/<Lib> /data/.h5p/'


### PR DESCRIPTION
## Summary
- update README for new `--include-libraries` flag
- add `include_libraries` parameter and CLI option
- make `--pack` just zip by default
- keep optional library copy with `--include-libraries`

## Testing
- `python -m py_compile script.py` *(fails: missing python-pptx)*


------
https://chatgpt.com/codex/tasks/task_e_688661ed246883229c88641574478c04